### PR TITLE
Do automatic release to PyPi from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ after_failure: "cat _trial_temp/test.log"
 deploy:
   provider: pypi
   user: twistedchecker-robot
-  password: ENCRYPTED_PASS_HERE
+  password:
+    secure: ENCRYPTED-VALUE HERE
   on:
     tags: true
+    # All branches is still required.
+    # https://github.com/travis-ci/travis-ci/issues/1675
+    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,12 @@ script:
 
 # Dump trial log on failure.
 after_failure: "cat _trial_temp/test.log"
+
+# Do an automatic PyPi release when a tag is created.
+# http://docs.travis-ci.com/user/deployment/pypi/
+deploy:
+  provider: pypi
+  user: twistedchecker-robot
+  password: ENCRYPTED_PASS_HERE
+  on:
+    tags: true


### PR DESCRIPTION
As commented by @glyph  in #83 it would be nice to have automatic deployment to PyPi.

Travis CI has support for this http://docs.travis-ci.com/user/deployment/pypi/

More info here about why all_branches is required
http://docs.travis-ci.com/user/deployment/#Conditional-Releases-with-on%3A

I have pushed an initial change to travis config file.

I think that is better to create a new PyPi account dedicated for this auto publishing process.

To have this working someone need to create an account on PyPi and send me the encrypted password.

Another option, is to give me permissions to PyPi and GitHub for twistedcheker project, and I can take care of the rest.

Thanks!