### PR TITLE
don't be overly zealous about checking the right hand of % for tuples

### DIFF
--- a/twistedchecker/checkers/formattingoperation.py
+++ b/twistedchecker/checkers/formattingoperation.py
@@ -27,10 +27,16 @@ class FormattingOperationChecker(StringFormatChecker):
         if node.op != "%":
             return
         pattern = node.left.as_string()
+        # If the pattern's not a constant string, we don't know whether a
+        # dictionary or a tuple makes sense, so don't try to guess.
+        if not pattern.startswith("'") or pattern.startswith('"'):
+            return
+        # If the pattern has things like %(foo)s, then the values can't be a
+        # tuple, so don't check for it.
+        if "%(" in pattern:
+            return
         valueString = node.right.as_string()
-        # If the pattern has things like %(foo)s,
-        # then the values can't be a tuple, so don't check for it.
-        if "%(" not in pattern:
-            tupleUsed = valueString.startswith('(')
-            if not tupleUsed:
-                self.add_message('W9501', node=node)
+        tupleUsed = valueString.startswith('(')
+        if tupleUsed:
+            return
+        self.add_message('W9501', node=node)

--- a/twistedchecker/functionaltests/formattingoperation.py
+++ b/twistedchecker/functionaltests/formattingoperation.py
@@ -1,5 +1,5 @@
 # enable: W9501
-
+# -*- test-case-name: twistedchecker.test.test_functionaltests -*-
 
 num = 3
 # we should use a tuple as the value
@@ -15,3 +15,8 @@ formattedString = "%(num)d" % mapFoo
 num = 3
 # a tuple used in the string formatting operation.
 formattedString = "%d" % (num,)
+
+# a formatting operation using mapping value
+# no warnings should be generated
+constantFormat = "a format %(value)s"
+constantFormat % {"value": "value"}


### PR DESCRIPTION
`foo % bar` is a perfectly cromulent thing to have in python code.
