### PR TITLE
twistedchecker does not report warnings as a non-zero exit code

### DIFF
--- a/twistedchecker/checkers/__init__.py
+++ b/twistedchecker/checkers/__init__.py
@@ -1,3 +1,6 @@
+# -*- test-case-name: twistedchecker.test -*-
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
 """
 Checkers of Twistedchecker.
 """

--- a/twistedchecker/core/runner.py
+++ b/twistedchecker/core/runner.py
@@ -316,6 +316,8 @@ class Runner():
             exitCode = 1 if diffCount else 0
             sys.exit(exitCode)
 
+        sys.exit(self.linter.msg_status)
+
 
     def prepareDiff(self):
         """

--- a/twistedchecker/test/test_functionaltests.py
+++ b/twistedchecker/test/test_functionaltests.py
@@ -47,7 +47,11 @@ def _partial2(wrapped, *partialArgs, **partialKwargs):
     def wrapper(*args, **kwargs):
         args = args + partialArgs[len(args):]
         kwargs.update(partialKwargs)
-        return wrapped(*args, **kwargs)
+        try:
+            wrapped(*args, **kwargs)
+        except SystemExit:
+            # Each run of the functional tests will exit at the end.
+            pass
     return update_wrapper(wrapper, wrapped)
 
 

--- a/twistedchecker/test/test_limitedreporter.py
+++ b/twistedchecker/test/test_limitedreporter.py
@@ -18,8 +18,9 @@ class LimitedReporterTestCase(unittest.TestCase):
         Test for LimitedReporter.
         Use test file of indentation to test
         whether limited messages are returned when using LimitedReporter.
-        Defaultly test on this test file will return two warnings:
-        W0311 and W0312.
+
+        Complete run on the test file will return two warnings:
+        W0311 and W0312, but with limited report it returns only one.
         """
         moduleTestIndentation = "twistedchecker.functionaltests.indentation"
         pathTestIndentation = os.path.join(twistedchecker.abspath,
@@ -32,8 +33,12 @@ class LimitedReporterTestCase(unittest.TestCase):
         # defaultly, runner will use LimitedReporter as its output reporter
         # set allowed messages for it
         runner.linter.reporter.messagesAllowed = set(["W0311"])
-        runner.run([moduleTestIndentation])
+
+        exitResult = self.assertRaises(
+            SystemExit, runner.run, [moduleTestIndentation])
+
         # check the results to see only W0311 is reported
         resultTest = streamTestResult.getvalue()
         self.assertTrue("W0311" in resultTest)
         self.assertTrue("W0312" not in resultTest)
+        self.assertEqual(4, exitResult.code)

--- a/twistedchecker/test/test_runner.py
+++ b/twistedchecker/test/test_runner.py
@@ -162,6 +162,36 @@ class RunnerTestCase(unittest.TestCase):
         self.assertEqual(0, exitResult.code)
 
 
+    def test_runNoError(self):
+        """
+        When checked file is clean and has no errors it exit with code 0
+        without any other output.
+        """
+        runner = Runner()
+        runner.setOutput(self.outputStream)
+
+        # The twistedchecker/checkers/__init__.py is assumed to be clean.
+        exitResult = self.assertRaises(SystemExit, runner.run, [
+            "twistedchecker.checkers.__init__"])
+
+        self.assertEqual('', self.outputStream.getvalue())
+        self.assertEqual(0, exitResult.code)
+
+
+    def test_runWithErrors(self):
+        """
+        When checked file is not clean it will exit with non zero exit code.
+        """
+        runner = Runner()
+        runner.setOutput(self.outputStream)
+
+        # The comments functional test is assumed to have at lest one error.
+        exitResult = self.assertRaises(SystemExit, runner.run, [
+            "twistedchecker.functionaltests.comments"])
+
+        self.assertNotEqual(0, exitResult.code)
+
+
     def test_parseWarnings(self):
         """
         Test for twistedchecker.core.runner.Runner.parseWarnings.

--- a/twistedchecker/test/test_runner.py
+++ b/twistedchecker/test/test_runner.py
@@ -398,9 +398,11 @@ C0111:  10,0: Missing docstring
         workingDir = os.getcwd()
         os.chdir(os.path.dirname(pathTestFiles))
         moduleName = os.path.basename(pathTestFiles)
-        runner.run([moduleName])
-        os.chdir(workingDir)
 
+        exitResult = self.assertRaises(SystemExit, runner.run, [moduleName])
+
+        os.chdir(workingDir)
         predictResult = "11:C0103\n14:C0103\n15:C0103\n"
         outputResult = self.outputStream.getvalue()
         self.assertEqual(outputResult, predictResult)
+        self.assertEqual(16, exitResult.code)


### PR DESCRIPTION
this makes it awkward to, for example, fail a tox build if twistedchecker fails