### PR TITLE
test methods in TestCases don't need a @return annotation

### DIFF
--- a/twistedchecker/checkers/docstring.py
+++ b/twistedchecker/checkers/docstring.py
@@ -215,6 +215,9 @@ class DocstringChecker(PylintDocStringChecker):
                                  node=node, args=argname)
         # Check for return value.
         if self._hasReturnValue(node):
+            if node.name.startswith('test_'):
+                # Ignore return documentation for test methods.
+                return
             if not re.search(r"@return[s]{0,1}\s*:", node.doc):
                 self.add_message('W9204', line=linenoDocstring, node=node)
             if not re.search(r"@rtype\s*:", node.doc):

--- a/twistedchecker/functionaltests/docstring_pass.py
+++ b/twistedchecker/functionaltests/docstring_pass.py
@@ -65,6 +65,13 @@ class foo:
         return
 
 
+    def test_someTest(self):
+        """
+        Test methods in trial should not document their return value.
+        """
+        return 'deferred'
+
+
 
 class Bar(object):
     """


### PR DESCRIPTION
test methods, if they have a return, return a deferred which fires when the test completes. They don't all need an annoation explaining this.

------------------------------------
Imported from Launchpad using lp2gh.

 * date created: 2012-12-31T19:28:04Z
 * owner: tom.prince
 * the launchpad url was https://bugs.launchpad.net/bugs/1094942
