### PR TITLE
test modules should not need a test-case-name

### DIFF
--- a/twistedchecker/checkers/header.py
+++ b/twistedchecker/checkers/header.py
@@ -66,5 +66,9 @@ class HeaderChecker(BaseChecker):
         @param text: codes of the module
         @param node: node of the module
         """
+        if '.test.' in node.name or '.test_' in node.name:
+            # Test packages or test modules don't need references to tests.
+            return
+
         if not re.search(self.patternTestReference, text):
             self.add_message('W9002', node=node)

--- a/twistedchecker/functionaltests/test_referencetotest_for_tests.py
+++ b/twistedchecker/functionaltests/test_referencetotest_for_tests.py
@@ -1,0 +1,6 @@
+# enable: W9002
+
+# Test modules don't need a reference to a test.
+
+def test_something():
+    pass


### PR DESCRIPTION
I see `[W9002] Missing a reference to test module in header` in any new test module, which is bogus, `test_*.py` modules don't require such an annotation.