### PR TITLE
necessarily long comments are reported as errors

### DIFF
--- a/twistedchecker/checkers/patch_pylint_format.py
+++ b/twistedchecker/checkers/patch_pylint_format.py
@@ -13,7 +13,7 @@ def check_lines(self, lines, i):
     maxChars = self.config.max_line_length
     for line in lines.splitlines():
         if len(line) > maxChars:
-            if 'http://' in line or 'https' in line:
+            if 'http://' in line or 'https://' in line:
                 continue
             self.add_message('C0301', line=i, args=(len(line), maxChars))
         i += 1

--- a/twistedchecker/checkers/patch_pylint_format.py
+++ b/twistedchecker/checkers/patch_pylint_format.py
@@ -1,0 +1,29 @@
+"""
+Extension of pylint format checkers.
+"""
+from pylint.checkers.format import FormatChecker
+
+
+def check_lines(self, lines, i):
+    """
+    check lines have less than a maximum number of characters.
+
+    It ignored lines with long URLs.
+    """
+    maxChars = self.config.max_line_length
+    for line in lines.splitlines():
+        if len(line) > maxChars:
+            if 'http://' in line or 'https' in line:
+                continue
+            self.add_message('C0301', line=i, args=(len(line), maxChars))
+        i += 1
+
+
+
+def patch():
+    """
+    pylint thinks that its default checkers are so special that anybody
+    wants them so there is no clean way to prevent them from being loaded
+    or to unregister them.
+    """
+    FormatChecker.check_lines = check_lines

--- a/twistedchecker/core/runner.py
+++ b/twistedchecker/core/runner.py
@@ -14,6 +14,8 @@ from logilab.common.modutils import file_from_modpath
 import twistedchecker
 from twistedchecker.reporters.limited import LimitedReporter
 from twistedchecker.core.exceptionfinder import findAllExceptions
+from twistedchecker.checkers import patch_pylint_format
+
 
 class Runner():
     """
@@ -125,6 +127,9 @@ class Runner():
 
         @return: a list of allowed messages
         """
+        # We patch the default pylint format checker.
+        patch_pylint_format.patch()
+
         # add checkers for python 3
         cfgfile = self.linter.cfgfile_parser
         if (cfgfile.has_option("TWISTEDCHECKER", "check-python3") and

--- a/twistedchecker/functionaltests/maxlinelength.py
+++ b/twistedchecker/functionaltests/maxlinelength.py
@@ -7,5 +7,5 @@ print "this line is long long  long  long long long long long ends at column 80"
 
 """"
 Long url form docstrings are ignored.
-See U{http://thisurlisverylongandwillneverfitinto80columnsnomatterwhat.example.com/somegreatcontent.html}
+See U{https://thisurlisverylongandwillneverfitinto80columnsnomatterwhat.example.com/somegreatcontent.html}
 """

--- a/twistedchecker/functionaltests/maxlinelength.py
+++ b/twistedchecker/functionaltests/maxlinelength.py
@@ -1,3 +1,11 @@
 # enable: C0301
 # max line length of Twsited projects should be 79
 print "this line is long long  long  long long long long long ends at column 80"
+
+# But comments with url should be excepted.
+# http://thisurlisverylongandwillneverfitinto80columnsnomatterwhat.example.com/somegreatcontent.tml
+
+""""
+Long url form docstrings are ignored.
+See U{http://thisurlisverylongandwillneverfitinto80columnsnomatterwhat.example.com/somegreatcontent.html}
+"""


### PR DESCRIPTION
```
exarkun@top:/tmp$ cat longcomment.py 
# Copyright (c) Twisted Matrix Laboratories.
# See LICENSE for details.

# http://thisurlisverylongandwillneverfitinto80columnsnomatterwhat.example.com/somegreatcontent.tml

exarkun@top:/tmp$ PYTHONPATH=${PYTHONPATH}:~/Projects/twistedchecker/ ~/Projects/twistedchecker/bin/twistedchecker longcomment.py
************* Module longcomment
C0301:  4,0: Line too long (99/79)
W9402:  4,0: The first letter of comment should be capitalized
...
exarkun@top:/tmp$
```

Neither of these errors is appropriate.  "http" is arguably more correct than "Http" and there is no good way to make this line fit within the normal bounds.

------------------------------------
Imported from Launchpad using lp2gh.

 * date created: 2013-11-19T18:40:22Z
 * owner: exarkun
 * the launchpad url was https://bugs.launchpad.net/bugs/1252825
