### PR TITLE
Only run Travis CI test once for a PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ script:
 # Dump trial log on failure.
 after_failure: "cat _trial_temp/test.log"
 
+# Only run test when committing to master branch.
+branches:
+  only:
+    - master
+
 # Travis is a bit "simple" and will not automatically switch to the
 # deployment directory before running its own deploy code.
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ after_failure: "cat _trial_temp/test.log"
 branches:
   only:
     - master
+    - \d+\.\d+\.\d+
 
 # Travis is a bit "simple" and will not automatically switch to the
 # deployment directory before running its own deploy code.


### PR DESCRIPTION
When a commit is pushed for a PR the Travis tests are executed twice.... once for PR and another one for the Push

It should only be called once.

I have opened this issues to document the changes required on github or travis-ci