### PR TITLE
fix using externally-defined decorator

### DIFF
--- a/twistedchecker/checkers/docstring.py
+++ b/twistedchecker/checkers/docstring.py
@@ -8,8 +8,7 @@ Checks for docstrings.
 
 import re
 
-from logilab.astng import node_classes
-from logilab.astng import scoped_nodes
+from logilab.astng import node_classes, scoped_nodes, YES
 from logilab.astng.exceptions import InferenceError
 
 from pylint.interfaces import IASTNGChecker
@@ -43,13 +42,23 @@ def _getDecoratorsName(node):
     @param node: current node of pylint
     """
     try:
-        return node.decoratornames()
+        names = node.decoratornames()
     except InferenceError:
-        # For setter properties pylint fails so we use a custom code.
-        decorators = []
-        for decorator in node.decorators.nodes:
-            decorators.append(decorator.as_string())
-        return decorators
+        # Sometimes astng fails by raising this kind of error.
+        pass
+    else:
+        for name in names:
+            if name is YES:
+                # Whereas sometimes it fails by returning this magic token.
+                break
+        else:
+            return names
+    # If pylint's attempt to discover the decorator's names has failed, fall
+    # back to our own logic.
+    decorators = []
+    for decorator in node.decorators.nodes:
+        decorators.append(decorator.as_string())
+    return decorators
 
 
 def _isSetter(node_type, node):

--- a/twistedchecker/checkers/docstring.py
+++ b/twistedchecker/checkers/docstring.py
@@ -47,11 +47,8 @@ def _getDecoratorsName(node):
         # Sometimes astng fails by raising this kind of error.
         pass
     else:
-        for name in names:
-            if name is YES:
-                # Whereas sometimes it fails by returning this magic token.
-                break
-        else:
+        # Whereas sometimes it fails by returning this magic token.
+        if YES not in names:
             return names
     # If pylint's attempt to discover the decorator's names has failed, fall
     # back to our own logic.

--- a/twistedchecker/functionaltests/docstring_pass.py
+++ b/twistedchecker/functionaltests/docstring_pass.py
@@ -131,7 +131,6 @@ class Bar(object):
 
 
 
-
 def topLevel():
     """
     A top-level function.
@@ -139,6 +138,7 @@ def topLevel():
     class Inner(object):
         def innerInner(self):
             pass
+
 
 
 class Baz(object):

--- a/twistedchecker/functionaltests/docstring_pass.py
+++ b/twistedchecker/functionaltests/docstring_pass.py
@@ -91,6 +91,9 @@ class foo:
 
     @aliasForProperty.setter
     def decorated(self):
+        # If we have a decorator which *might* be a property, but is imported
+        # from elsewhere (somewhere that pylint's parser can't see) then we
+        # also don't need a docstring for its setter.
         pass
 
 

--- a/twistedchecker/functionaltests/docstring_pass.py
+++ b/twistedchecker/functionaltests/docstring_pass.py
@@ -5,6 +5,8 @@ A docstring with a wrong indentation.
 Docstring should have consistent indentations.
 """
 
+from elsewhere import aliasForProperty
+
 class foo:
     """
     The opening/closing of docstring should be on a line by themselves.
@@ -84,6 +86,11 @@ class foo:
     def otherProperty(self, value):
         # Setter don't need a docstring as most of the time is a duplicate of
         # the getter docstring.
+        pass
+
+
+    @aliasForProperty.setter
+    def decorated(self):
         pass
 
 


### PR DESCRIPTION
If you use a decorator defined somewhere that twistedchecker can't "see", it fails with an exception.

This currently causes linting of `twisted.internet.endpoints`, `twisted.web.client`, `twisted.web.http`, and `twisted.mail.test.test_smtp` to fail with: 

```
Traceback (most recent call last):
  File ".../twistedchecker/checkers/docstring.py", line 68, in _isSetter
    if '.setter' in name:
TypeError: argument of type '_Yes' is not iterable
```

which may be obfuscating further lint errors.